### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DMPLayer is an Android music player prototype
 
 ![1](https://cloud.githubusercontent.com/assets/10453203/14409496/88646b84-ff32-11e5-8923-c8093e9bfb81.png) ![2](https://cloud.githubusercontent.com/assets/10453203/14409497/8bdefa36-ff32-11e5-8f88-b408eaf420c5.png) ![3](https://cloud.githubusercontent.com/assets/10453203/14409498/8c130d1c-ff32-11e5-92de-60eb154d6a9e.png) ![4](https://cloud.githubusercontent.com/assets/10453203/14409499/8c412ec2-ff32-11e5-892e-2ef6e26f88ef.png) ![5](https://cloud.githubusercontent.com/assets/10453203/14409500/8c45d120-ff32-11e5-903d-ed27e4d4b50c.png) ![6](https://cloud.githubusercontent.com/assets/10453203/14409501/8c4f6762-ff32-11e5-938d-048dc5164073.png) ![7](https://cloud.githubusercontent.com/assets/10453203/14409502/8c54caf4-ff32-11e5-83bf-88bb1d56465f.png) ![8](https://cloud.githubusercontent.com/assets/10453203/14409503/8d0ed818-ff32-11e5-97e5-b9ccd7919e18.png) ![9](https://cloud.githubusercontent.com/assets/10453203/14409504/8d98e09e-ff32-11e5-9994-2f604f2db5f3.png)
 
-#License
+# License
 Copyright 2015 dibakar.ece@gmail.com Dibakar Mistry
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License in the LICENSE file, or at:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
